### PR TITLE
Queue handler

### DIFF
--- a/src/main/java/executor/service/publisher/config/Config.java
+++ b/src/main/java/executor/service/publisher/config/Config.java
@@ -1,0 +1,17 @@
+package executor.service.publisher.config;
+
+import executor.service.publisher.model.ProxyConfigHolderDto;
+import executor.service.publisher.queue.ProxySourceQueueHandler;
+import executor.service.publisher.queue.QueueHandler;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.concurrent.ConcurrentLinkedQueue;
+
+@Configuration
+public class Config {
+    @Bean
+    public QueueHandler<ProxyConfigHolderDto> proxyQueueHandler() {
+        return new ProxySourceQueueHandler(new ConcurrentLinkedQueue<>());
+    }
+}

--- a/src/main/java/executor/service/publisher/queue/ProxySourceQueueHandler.java
+++ b/src/main/java/executor/service/publisher/queue/ProxySourceQueueHandler.java
@@ -5,13 +5,10 @@ import org.springframework.stereotype.Component;
 
 import java.util.*;
 import java.util.concurrent.ConcurrentLinkedQueue;
+
 @Component
 public class ProxySourceQueueHandler implements QueueHandler<ProxyConfigHolderDto> {
-    private final Queue<ProxyConfigHolderDto> proxies;
-
-    public ProxySourceQueueHandler() {
-        proxies = new ConcurrentLinkedQueue<>();
-    }
+    private final Queue<ProxyConfigHolderDto> proxies = new ConcurrentLinkedQueue<>();
 
     @Override
     public void add(ProxyConfigHolderDto element) {

--- a/src/main/java/executor/service/publisher/queue/ProxySourceQueueHandler.java
+++ b/src/main/java/executor/service/publisher/queue/ProxySourceQueueHandler.java
@@ -1,14 +1,15 @@
 package executor.service.publisher.queue;
 
 import executor.service.publisher.model.ProxyConfigHolderDto;
-import org.springframework.stereotype.Component;
 
 import java.util.*;
-import java.util.concurrent.ConcurrentLinkedQueue;
 
-@Component
 public class ProxySourceQueueHandler implements QueueHandler<ProxyConfigHolderDto> {
-    private final Queue<ProxyConfigHolderDto> proxies = new ConcurrentLinkedQueue<>();
+    private final Queue<ProxyConfigHolderDto> proxies;
+
+    public ProxySourceQueueHandler(Queue<ProxyConfigHolderDto> proxies) {
+        this.proxies = proxies;
+    }
 
     @Override
     public void add(ProxyConfigHolderDto element) {

--- a/src/main/java/executor/service/publisher/queue/ProxySourceQueueHandler.java
+++ b/src/main/java/executor/service/publisher/queue/ProxySourceQueueHandler.java
@@ -5,10 +5,10 @@ import executor.service.publisher.model.ProxyConfigHolderDto;
 import java.util.*;
 import java.util.concurrent.ConcurrentLinkedQueue;
 
-public class ProxySourceQueueHandlerImpl<T> implements QueueHandler<ProxyConfigHolderDto> {
+public class ProxySourceQueueHandler<T> implements QueueHandler<ProxyConfigHolderDto> {
     private final Queue<ProxyConfigHolderDto> proxies;
 
-    public ProxySourceQueueHandlerImpl() {
+    public ProxySourceQueueHandler() {
         proxies = new ConcurrentLinkedQueue<>();
     }
 

--- a/src/main/java/executor/service/publisher/queue/ProxySourceQueueHandler.java
+++ b/src/main/java/executor/service/publisher/queue/ProxySourceQueueHandler.java
@@ -1,11 +1,12 @@
 package executor.service.publisher.queue;
 
 import executor.service.publisher.model.ProxyConfigHolderDto;
+import org.springframework.stereotype.Component;
 
 import java.util.*;
 import java.util.concurrent.ConcurrentLinkedQueue;
-
-public class ProxySourceQueueHandler<T> implements QueueHandler<ProxyConfigHolderDto> {
+@Component
+public class ProxySourceQueueHandler implements QueueHandler<ProxyConfigHolderDto> {
     private final Queue<ProxyConfigHolderDto> proxies;
 
     public ProxySourceQueueHandler() {

--- a/src/main/java/executor/service/publisher/queue/ProxySourceQueueHandlerImpl.java
+++ b/src/main/java/executor/service/publisher/queue/ProxySourceQueueHandlerImpl.java
@@ -1,0 +1,40 @@
+package executor.service.publisher.queue;
+
+import executor.service.publisher.model.ProxyConfigHolderDto;
+
+import java.util.*;
+import java.util.concurrent.ConcurrentLinkedQueue;
+
+public class ProxySourceQueueHandlerImpl<T> implements QueueHandler<ProxyConfigHolderDto> {
+    private final Queue<ProxyConfigHolderDto> proxies;
+
+    public ProxySourceQueueHandlerImpl() {
+        proxies = new ConcurrentLinkedQueue<>();
+    }
+
+    @Override
+    public void add(ProxyConfigHolderDto element) {
+        proxies.add(element);
+    }
+
+    @Override
+    public void addAll(List<ProxyConfigHolderDto> elements) {
+        proxies.addAll(elements);
+    }
+
+    @Override
+    public Optional<ProxyConfigHolderDto> poll() {
+        return Optional.ofNullable(proxies.poll());
+    }
+
+    @Override
+    public List<ProxyConfigHolderDto> removeAll() {
+        List<ProxyConfigHolderDto> removedProxies = new ArrayList<>();
+        ProxyConfigHolderDto removed = proxies.poll();
+        while (removed != null) {
+            removedProxies.add(removed);
+            removed = proxies.poll();
+        }
+        return removedProxies;
+    }
+}

--- a/src/main/java/executor/service/publisher/queue/QueueHandler.java
+++ b/src/main/java/executor/service/publisher/queue/QueueHandler.java
@@ -1,0 +1,14 @@
+package executor.service.publisher.queue;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface QueueHandler<T> {
+    void add(T element);
+
+    void addAll(List<T> elements);
+
+    Optional<T> poll();
+
+    List<T> removeAll();
+}

--- a/src/test/java/executor/service/publisher/queue/ProxySourceQueueHandlerMockTest.java
+++ b/src/test/java/executor/service/publisher/queue/ProxySourceQueueHandlerMockTest.java
@@ -1,0 +1,64 @@
+package executor.service.publisher.queue;
+
+import executor.service.publisher.model.ProxyConfigHolderDto;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+
+import java.lang.reflect.Field;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentLinkedQueue;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+
+public class ProxySourceQueueHandlerMockTest {
+    private QueueHandler<ProxyConfigHolderDto> queueHandler;
+    @Mock
+    private ConcurrentLinkedQueue<ProxyConfigHolderDto> proxies;
+
+    @BeforeEach
+    public void setUp() throws NoSuchFieldException, IllegalAccessException {
+        proxies = mock(ConcurrentLinkedQueue.class);
+        queueHandler = new ProxySourceQueueHandlerImpl<>();
+        Field proxiesField = ProxySourceQueueHandlerImpl.class.getDeclaredField("proxies");
+        proxiesField.setAccessible(true);
+        proxiesField.set(queueHandler, proxies);
+    }
+
+    @Test
+    public void testAdd() {
+        ProxyConfigHolderDto element = new ProxyConfigHolderDto();
+        queueHandler.add(element);
+        verify(proxies, times(1)).add(element);
+    }
+
+    @Test
+    public void testAddAll() {
+        List<ProxyConfigHolderDto> elements = List.of(new ProxyConfigHolderDto(), new ProxyConfigHolderDto());
+        queueHandler.addAll(elements);
+        verify(proxies, times(1)).addAll(elements);
+    }
+
+    @Test
+    public void testPoll() {
+        ProxyConfigHolderDto expected = new ProxyConfigHolderDto();
+        when(proxies.poll()).thenReturn(expected);
+        Optional<ProxyConfigHolderDto> result = queueHandler.poll();
+        assertThat(result).isPresent().contains(expected);
+        verify(proxies, times(1)).poll();
+    }
+
+    @Test
+    public void testRemoveAll() {
+        ProxyConfigHolderDto proxy1 = new ProxyConfigHolderDto();
+        ProxyConfigHolderDto proxy2 = new ProxyConfigHolderDto();
+        List<ProxyConfigHolderDto> expected = List.of(proxy1, proxy2);
+        when(proxies.poll()).thenReturn(proxy1, proxy2, null);
+        List<ProxyConfigHolderDto> result = queueHandler.removeAll();
+        assertThat(result).isEqualTo(expected);
+        verify(proxies, times(3)).poll();
+    }
+
+}

--- a/src/test/java/executor/service/publisher/queue/ProxySourceQueueHandlerMockTest.java
+++ b/src/test/java/executor/service/publisher/queue/ProxySourceQueueHandlerMockTest.java
@@ -21,8 +21,8 @@ public class ProxySourceQueueHandlerMockTest {
     @BeforeEach
     public void setUp() throws NoSuchFieldException, IllegalAccessException {
         proxies = mock(ConcurrentLinkedQueue.class);
-        queueHandler = new ProxySourceQueueHandlerImpl<>();
-        Field proxiesField = ProxySourceQueueHandlerImpl.class.getDeclaredField("proxies");
+        queueHandler = new ProxySourceQueueHandler<>();
+        Field proxiesField = ProxySourceQueueHandler.class.getDeclaredField("proxies");
         proxiesField.setAccessible(true);
         proxiesField.set(queueHandler, proxies);
     }

--- a/src/test/java/executor/service/publisher/queue/ProxySourceQueueHandlerMockTest.java
+++ b/src/test/java/executor/service/publisher/queue/ProxySourceQueueHandlerMockTest.java
@@ -5,7 +5,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 
-import java.lang.reflect.Field;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentLinkedQueue;
@@ -19,12 +18,9 @@ public class ProxySourceQueueHandlerMockTest {
     private ConcurrentLinkedQueue<ProxyConfigHolderDto> proxies;
 
     @BeforeEach
-    public void setUp() throws NoSuchFieldException, IllegalAccessException {
+    public void setUp() {
         proxies = mock(ConcurrentLinkedQueue.class);
-        queueHandler = new ProxySourceQueueHandler();
-        Field proxiesField = ProxySourceQueueHandler.class.getDeclaredField("proxies");
-        proxiesField.setAccessible(true);
-        proxiesField.set(queueHandler, proxies);
+        queueHandler = new ProxySourceQueueHandler(proxies);
     }
 
     @Test

--- a/src/test/java/executor/service/publisher/queue/ProxySourceQueueHandlerMockTest.java
+++ b/src/test/java/executor/service/publisher/queue/ProxySourceQueueHandlerMockTest.java
@@ -21,7 +21,7 @@ public class ProxySourceQueueHandlerMockTest {
     @BeforeEach
     public void setUp() throws NoSuchFieldException, IllegalAccessException {
         proxies = mock(ConcurrentLinkedQueue.class);
-        queueHandler = new ProxySourceQueueHandler<>();
+        queueHandler = new ProxySourceQueueHandler();
         Field proxiesField = ProxySourceQueueHandler.class.getDeclaredField("proxies");
         proxiesField.setAccessible(true);
         proxiesField.set(queueHandler, proxies);

--- a/src/test/java/executor/service/publisher/queue/ProxySourceQueueHandlerThreadSafetyTest.java
+++ b/src/test/java/executor/service/publisher/queue/ProxySourceQueueHandlerThreadSafetyTest.java
@@ -76,5 +76,6 @@ class ProxySourceQueueHandlerThreadSafetyTest {
         IntStream.range(0, THREAD_COUNT).forEach(v -> executorService.submit(removeAllTask));
         latch.await();
         assertEquals(ELEMENT_COUNT, resultSize.get());
+        assertEquals(0, queueHandler.removeAll().size());
     }
 }

--- a/src/test/java/executor/service/publisher/queue/ProxySourceQueueHandlerThreadSafetyTest.java
+++ b/src/test/java/executor/service/publisher/queue/ProxySourceQueueHandlerThreadSafetyTest.java
@@ -20,15 +20,16 @@ class ProxySourceQueueHandlerThreadSafetyTest {
 
     private QueueHandler<ProxyConfigHolderDto> queueHandler;
     private CountDownLatch latch;
+    private ExecutorService executorService;
     @BeforeEach
     public void setUp() {
         queueHandler = new ProxySourceQueueHandler(new ConcurrentLinkedQueue<>());
         latch = new CountDownLatch(THREAD_COUNT);
+        executorService = Executors.newFixedThreadPool(THREAD_COUNT);
     }
 
     @Test
     public void testAddMethodThreadSafety() throws InterruptedException {
-        ExecutorService executorService = Executors.newFixedThreadPool(THREAD_COUNT);
         Runnable addTask = () -> {
             queueHandler.add(new ProxyConfigHolderDto());
             latch.countDown();
@@ -41,7 +42,6 @@ class ProxySourceQueueHandlerThreadSafetyTest {
     @Test
     public void testAddAllMethodThreadSafety() throws InterruptedException {
         List<ProxyConfigHolderDto> elements = IntStream.range(0, ELEMENT_COUNT).boxed().map(v -> new ProxyConfigHolderDto()).toList();
-        ExecutorService executorService = Executors.newFixedThreadPool(THREAD_COUNT);
         Runnable addAllTask = () -> {
             queueHandler.addAll(elements);
             latch.countDown();
@@ -54,7 +54,6 @@ class ProxySourceQueueHandlerThreadSafetyTest {
     @Test
     public void testPollMethodThreadSafety() throws InterruptedException {
         IntStream.range(0, ELEMENT_COUNT).forEach(i -> queueHandler.add(new ProxyConfigHolderDto()));
-        ExecutorService executorService = Executors.newFixedThreadPool(THREAD_COUNT);
         Runnable pollTask = () -> {
             queueHandler.poll();
             latch.countDown();
@@ -67,7 +66,6 @@ class ProxySourceQueueHandlerThreadSafetyTest {
     @Test
     public void testRemoveAllMethodThreadSafety() throws InterruptedException {
         IntStream.range(0, ELEMENT_COUNT).forEach(i -> queueHandler.add(new ProxyConfigHolderDto()));
-        ExecutorService executorService = Executors.newFixedThreadPool(THREAD_COUNT);
         AtomicInteger resultSize = new AtomicInteger(0);
         Runnable removeAllTask = () -> {
             resultSize.addAndGet(queueHandler.removeAll().size());

--- a/src/test/java/executor/service/publisher/queue/ProxySourceQueueHandlerThreadSafetyTest.java
+++ b/src/test/java/executor/service/publisher/queue/ProxySourceQueueHandlerThreadSafetyTest.java
@@ -21,7 +21,7 @@ class ProxySourceQueueHandlerThreadSafetyTest {
     private CountDownLatch latch;
     @BeforeEach
     public void setUp() {
-        queueHandler = new ProxySourceQueueHandler<>();
+        queueHandler = new ProxySourceQueueHandler();
         latch = new CountDownLatch(THREAD_COUNT);
     }
 

--- a/src/test/java/executor/service/publisher/queue/ProxySourceQueueHandlerThreadSafetyTest.java
+++ b/src/test/java/executor/service/publisher/queue/ProxySourceQueueHandlerThreadSafetyTest.java
@@ -21,7 +21,7 @@ class ProxySourceQueueHandlerThreadSafetyTest {
     private CountDownLatch latch;
     @BeforeEach
     public void setUp() {
-        queueHandler = new ProxySourceQueueHandlerImpl<>();
+        queueHandler = new ProxySourceQueueHandler<>();
         latch = new CountDownLatch(THREAD_COUNT);
     }
 

--- a/src/test/java/executor/service/publisher/queue/ProxySourceQueueHandlerThreadSafetyTest.java
+++ b/src/test/java/executor/service/publisher/queue/ProxySourceQueueHandlerThreadSafetyTest.java
@@ -5,6 +5,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
+import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -21,7 +22,7 @@ class ProxySourceQueueHandlerThreadSafetyTest {
     private CountDownLatch latch;
     @BeforeEach
     public void setUp() {
-        queueHandler = new ProxySourceQueueHandler();
+        queueHandler = new ProxySourceQueueHandler(new ConcurrentLinkedQueue<>());
         latch = new CountDownLatch(THREAD_COUNT);
     }
 

--- a/src/test/java/executor/service/publisher/queue/ProxySourceQueueHandlerThreadSafetyTest.java
+++ b/src/test/java/executor/service/publisher/queue/ProxySourceQueueHandlerThreadSafetyTest.java
@@ -1,0 +1,79 @@
+package executor.service.publisher.queue;
+
+import executor.service.publisher.model.ProxyConfigHolderDto;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.IntStream;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class ProxySourceQueueHandlerThreadSafetyTest {
+    private static final int THREAD_COUNT = 8;
+    private static final int ELEMENT_COUNT = 100;
+
+    private QueueHandler<ProxyConfigHolderDto> queueHandler;
+    private CountDownLatch latch;
+    @BeforeEach
+    public void setUp() {
+        queueHandler = new ProxySourceQueueHandlerImpl<>();
+        latch = new CountDownLatch(THREAD_COUNT);
+    }
+
+    @Test
+    public void testAddMethodThreadSafety() throws InterruptedException {
+        ExecutorService executorService = Executors.newFixedThreadPool(THREAD_COUNT);
+        Runnable addTask = () -> {
+            queueHandler.add(new ProxyConfigHolderDto());
+            latch.countDown();
+        };
+        IntStream.range(0, THREAD_COUNT).forEach(v -> executorService.submit(addTask));
+        latch.await();
+        assertEquals(THREAD_COUNT, queueHandler.removeAll().size());
+    }
+
+    @Test
+    public void testAddAllMethodThreadSafety() throws InterruptedException {
+        List<ProxyConfigHolderDto> elements = IntStream.range(0, ELEMENT_COUNT).boxed().map(v -> new ProxyConfigHolderDto()).toList();
+        ExecutorService executorService = Executors.newFixedThreadPool(THREAD_COUNT);
+        Runnable addAllTask = () -> {
+            queueHandler.addAll(elements);
+            latch.countDown();
+        };
+        IntStream.range(0, THREAD_COUNT).forEach(v -> executorService.submit(addAllTask));
+        latch.await();
+        assertEquals(THREAD_COUNT * ELEMENT_COUNT, queueHandler.removeAll().size());
+    }
+
+    @Test
+    public void testPollMethodThreadSafety() throws InterruptedException {
+        IntStream.range(0, ELEMENT_COUNT).forEach(i -> queueHandler.add(new ProxyConfigHolderDto()));
+        ExecutorService executorService = Executors.newFixedThreadPool(THREAD_COUNT);
+        Runnable pollTask = () -> {
+            queueHandler.poll();
+            latch.countDown();
+        };
+        IntStream.range(0, THREAD_COUNT).forEach(v -> executorService.submit(pollTask));
+        latch.await();
+        assertEquals(ELEMENT_COUNT - THREAD_COUNT, queueHandler.removeAll().size());
+    }
+
+    @Test
+    public void testRemoveAllMethodThreadSafety() throws InterruptedException {
+        IntStream.range(0, ELEMENT_COUNT).forEach(i -> queueHandler.add(new ProxyConfigHolderDto()));
+        ExecutorService executorService = Executors.newFixedThreadPool(THREAD_COUNT);
+        AtomicInteger resultSize = new AtomicInteger(0);
+        Runnable removeAllTask = () -> {
+            resultSize.addAndGet(queueHandler.removeAll().size());
+            latch.countDown();
+        };
+        IntStream.range(0, THREAD_COUNT).forEach(v -> executorService.submit(removeAllTask));
+        latch.await();
+        assertEquals(ELEMENT_COUNT, resultSize.get());
+    }
+}


### PR DESCRIPTION
Added the QueueHandler interface and it`s implementation for working with ProxyConfigDto objects. 
Also created a configuration class where a bean is declared for injecting the implementation with a thread-safe collection.
Wrote mock and thread-safety tests.